### PR TITLE
[FEAT] JWT middleware + [VULN] SQLi в пошуку #8

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -17,6 +17,10 @@ def create_app(testing=False):
         init_db(app)
 
     from backend.app.routes.auth import auth_bp
+    from backend.app.routes.profile import profile_bp
+    from backend.app.routes.products import products_bp
     app.register_blueprint(auth_bp)
+    app.register_blueprint(profile_bp)
+    app.register_blueprint(products_bp)
 
     return app

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,30 @@
+from functools import wraps
+
+import jwt
+from flask import request, jsonify, current_app, g
+
+
+def jwt_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return jsonify({"error": "Токен відсутній"}), 401
+
+        token = auth_header.split(" ", 1)[1]
+        try:
+            payload = jwt.decode(
+                token,
+                current_app.config["JWT_SECRET_KEY"],
+                algorithms=["HS256"],
+            )
+        except jwt.ExpiredSignatureError:
+            return jsonify({"error": "Токен протермінований"}), 401
+        except jwt.InvalidTokenError:
+            return jsonify({"error": "Невалідний токен"}), 401
+
+        g.user_id = payload["user_id"]
+        g.user_role = payload.get("role", "buyer")
+        return f(*args, **kwargs)
+
+    return decorated

--- a/backend/app/routes/products.py
+++ b/backend/app/routes/products.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, request, jsonify
+
+from backend.app.db import get_db
+
+products_bp = Blueprint("products", __name__)
+
+
+@products_bp.route("/products", methods=["GET"])
+def search_products():
+    search = request.args.get("search", "")
+
+    db = get_db()
+    cur = db.cursor()
+
+    if search:
+        query = f"SELECT id, seller_id, title, description, price, category, image_url, created_at FROM products WHERE title ILIKE '%{search}%'"
+        cur.execute(query)
+    else:
+        cur.execute("SELECT id, seller_id, title, description, price, category, image_url, created_at FROM products")
+
+    rows = cur.fetchall()
+    cur.close()
+
+    products = []
+    for row in rows:
+        products.append({
+            "id": row[0],
+            "seller_id": row[1],
+            "title": row[2],
+            "description": row[3],
+            "price": float(row[4]),
+            "category": row[5],
+            "image_url": row[6],
+            "created_at": row[7].isoformat() if row[7] else None,
+        })
+
+    return jsonify({"products": products}), 200

--- a/backend/app/routes/profile.py
+++ b/backend/app/routes/profile.py
@@ -1,0 +1,31 @@
+from flask import Blueprint, jsonify, g
+
+from backend.app.middleware import jwt_required
+from backend.app.db import get_db
+
+profile_bp = Blueprint("profile", __name__)
+
+
+@profile_bp.route("/profile", methods=["GET"])
+@jwt_required
+def get_profile():
+    db = get_db()
+    cur = db.cursor()
+    cur.execute(
+        "SELECT id, email, phone, full_name, is_seller, is_admin FROM users WHERE id = %s",
+        (g.user_id,),
+    )
+    row = cur.fetchone()
+    cur.close()
+
+    if not row:
+        return jsonify({"error": "Користувача не знайдено"}), 404
+
+    return jsonify({
+        "id": row[0],
+        "email": row[1],
+        "phone": row[2],
+        "full_name": row[3],
+        "is_seller": row[4],
+        "is_admin": row[5],
+    }), 200

--- a/backend/tests/functional/test_middleware.py
+++ b/backend/tests/functional/test_middleware.py
@@ -1,0 +1,42 @@
+import datetime
+import jwt
+
+
+def _make_token(app, user_id=1, role="buyer", expired=False):
+    if expired:
+        exp = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    else:
+        exp = datetime.datetime.utcnow() + datetime.timedelta(hours=24)
+    payload = {"user_id": user_id, "role": role, "exp": exp}
+    return jwt.encode(payload, app.config["JWT_SECRET_KEY"], algorithm="HS256")
+
+
+class TestJwtMiddleware:
+    def test_protected_route_without_token(self, client):
+        resp = client.get("/profile")
+        assert resp.status_code == 401
+
+    def test_protected_route_with_valid_token(self, client, app):
+        reg = client.post("/register", json={
+            "email": "jwt@example.com",
+            "phone": "+380501234567",
+            "password": "securePass1",
+        })
+        token = reg.get_json()["token"]
+        resp = client.get("/profile", headers={
+            "Authorization": f"Bearer {token}",
+        })
+        assert resp.status_code == 200
+
+    def test_protected_route_with_expired_token(self, client, app):
+        token = _make_token(app, expired=True)
+        resp = client.get("/profile", headers={
+            "Authorization": f"Bearer {token}",
+        })
+        assert resp.status_code == 401
+
+    def test_protected_route_with_invalid_token(self, client):
+        resp = client.get("/profile", headers={
+            "Authorization": "Bearer invalid.token.here",
+        })
+        assert resp.status_code == 401

--- a/backend/tests/functional/test_products.py
+++ b/backend/tests/functional/test_products.py
@@ -1,0 +1,13 @@
+class TestProducts:
+    def test_products_empty(self, client):
+        resp = client.get("/products")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "products" in data
+        assert isinstance(data["products"], list)
+
+    def test_products_search(self, client):
+        resp = client.get("/products?search=test")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "products" in data

--- a/backend/tests/security/test_sqli.py
+++ b/backend/tests/security/test_sqli.py
@@ -1,0 +1,11 @@
+class TestSearchSqli:
+    def test_search_sqli(self, client, app):
+        resp = client.get("/products?search=' OR 1=1--")
+        data = resp.get_json()
+
+        resp_normal = client.get("/products?search=nonexistent_product_xyz")
+        data_normal = resp_normal.get_json()
+
+        assert len(data["products"]) > len(data_normal["products"]), (
+            "SQLi payload ' OR 1=1-- should return more results than a normal search"
+        )


### PR DESCRIPTION
Closes #5, #8

## Що зроблено
- @jwt_required декоратор — middleware.py
- GET /profile — захищений роут
- GET /products?search= — навмисна SQLi (#8)

## Тести
- 15 functional ✅
- 2 security ❌ (навмисно: username enum #6 + SQLi #8)