### PR TITLE
[DOCS] OpenAPI / Swagger — /api/docs з basic auth

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,11 +1,20 @@
-from flask import Flask
+import os
+
+from flask import Flask, request, Response
+from functools import wraps
 
 from backend.app.config import Config
 from backend.app.db import close_db, init_db
 
 
+def _check_basic_auth(username, password):
+    return (
+        username == Config.API_DOCS_USERNAME
+        and password == Config.API_DOCS_PASSWORD
+    )
+
+
 def create_app(testing=False):
-    import os
     template_dir = os.path.join(os.path.dirname(__file__), "..", "..", "frontend", "templates")
     static_dir = os.path.join(os.path.dirname(__file__), "..", "..", "frontend", "static")
     app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
@@ -18,6 +27,28 @@ def create_app(testing=False):
 
     with app.app_context():
         init_db(app)
+
+    specs_dir = os.path.join(os.path.dirname(__file__), "..", "..", "docs", "api")
+    app.config["SWAGGER"] = {
+        "title": "PivdenShop API",
+        "uiversion": 3,
+        "specs_route": "/api/docs/",
+        "openapi": "3.0.3",
+    }
+
+    from flasgger import Swagger
+    Swagger(app, template_file=os.path.join(specs_dir, "auth.yaml"))
+
+    @app.before_request
+    def protect_api_docs():
+        if request.path.startswith("/api/docs") or request.path.startswith("/apispec") or request.path.startswith("/flasgger_static"):
+            auth = request.authorization
+            if not auth or not _check_basic_auth(auth.username, auth.password):
+                return Response(
+                    "Необхідна автентифікація",
+                    401,
+                    {"WWW-Authenticate": 'Basic realm="API Docs"'},
+                )
 
     from backend.app.routes.auth import auth_bp
     from backend.app.routes.profile import profile_bp

--- a/backend/tests/functional/test_api_docs.py
+++ b/backend/tests/functional/test_api_docs.py
@@ -1,0 +1,16 @@
+import base64
+
+
+class TestApiDocs:
+    def test_api_docs_requires_auth(self, client):
+        resp = client.get("/api/docs/")
+        assert resp.status_code == 401
+
+    def test_api_docs_accessible_with_auth(self, client, app):
+        username = app.config["API_DOCS_USERNAME"]
+        password = app.config["API_DOCS_PASSWORD"]
+        credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+        resp = client.get("/api/docs/", headers={
+            "Authorization": f"Basic {credentials}",
+        })
+        assert resp.status_code == 200

--- a/docs/api/auth.yaml
+++ b/docs/api/auth.yaml
@@ -1,0 +1,96 @@
+openapi: 3.0.3
+info:
+  title: PivdenShop Auth API
+  version: "1.0"
+  description: Автентифікація та реєстрація користувачів
+
+paths:
+  /register:
+    post:
+      tags:
+        - Auth
+      summary: Реєстрація нового користувача
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - phone
+                - password
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+                phone:
+                  type: string
+                  example: "+380501234567"
+                password:
+                  type: string
+                  minLength: 6
+                  example: securePass1
+      responses:
+        "201":
+          description: Успішна реєстрація
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      email:
+                        type: string
+                      phone:
+                        type: string
+                      role:
+                        type: string
+        "400":
+          description: Відсутні обов'язкові поля
+        "409":
+          description: Користувач з таким email вже існує
+
+  /login:
+    post:
+      tags:
+        - Auth
+      summary: Авторизація користувача
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+                password:
+                  type: string
+                  example: securePass1
+      responses:
+        "200":
+          description: Успішна авторизація
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        "400":
+          description: Відсутні обов'язкові поля
+        "401":
+          description: Невірні облікові дані


### PR DESCRIPTION
Closes #11

## Що зроблено
- flasgger підключено до app/__init__.py
- docs/api/auth.yaml — специфікація /register, /login
- /api/docs захищений basic auth (credentials в config.py)

## Тести
- functional: test_api_docs_requires_auth ✅
- functional: test_api_docs_accessible_with_auth ✅

## Вразливість
Захардкоджені credentials в config.py — вектор атаки (знайти і використати)