### PR TITLE
[VULN] JWT role manipulation #12 + /admin панель

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -58,10 +58,12 @@ def create_app(testing=False):
     from backend.app.routes.products import products_bp
     from backend.app.routes.main import main_bp
     from backend.app.routes.orders import orders_bp
+    from backend.app.routes.admin import admin_bp
     app.register_blueprint(auth_bp)
     app.register_blueprint(profile_bp)
     app.register_blueprint(products_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(orders_bp)
+    app.register_blueprint(admin_bp)
 
     return app

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, render_template, jsonify, g
+
+from backend.app.db import get_db
+from backend.app.middleware import jwt_required
+
+admin_bp = Blueprint("admin", __name__)
+
+
+@admin_bp.route("/admin", methods=["GET"])
+@jwt_required
+def admin_panel():
+    if g.user_role != "admin":
+        return jsonify({"error": "Доступ заборонено"}), 403
+
+    db = get_db()
+    cur = db.cursor()
+
+    cur.execute(
+        "SELECT id, email, full_name, is_seller, is_admin, created_at FROM users ORDER BY id"
+    )
+    users = []
+    for row in cur.fetchall():
+        role = "admin" if row[4] else ("seller" if row[3] else "buyer")
+        users.append({
+            "id": row[0],
+            "email": row[1],
+            "full_name": row[2],
+            "role": role,
+            "created_at": row[5].strftime("%d.%m.%Y %H:%M") if row[5] else "",
+        })
+
+    cur.execute(
+        "SELECT o.id, u.email, p.title, o.card_last4, o.card_number_plain, "
+        "o.status, o.created_at "
+        "FROM orders o "
+        "JOIN users u ON o.buyer_id = u.id "
+        "JOIN products p ON o.product_id = p.id "
+        "ORDER BY o.created_at DESC"
+    )
+    orders = []
+    for row in cur.fetchall():
+        orders.append({
+            "id": row[0],
+            "buyer_email": row[1],
+            "product_title": row[2],
+            "card_last4": row[3],
+            "card_number_plain": row[4],
+            "status": row[5],
+            "created_at": row[6].strftime("%d.%m.%Y %H:%M") if row[6] else "",
+        })
+
+    cur.close()
+
+    return render_template("admin.html", users=users, orders=orders)

--- a/backend/tests/functional/test_admin.py
+++ b/backend/tests/functional/test_admin.py
@@ -1,0 +1,47 @@
+import json
+import datetime
+import jwt
+
+
+class TestAdminPanel:
+    def _register(self, client, email="user@test.com", phone="0501234567"):
+        resp = client.post("/register", json={
+            "email": email,
+            "phone": phone,
+            "password": "password123",
+        })
+        return json.loads(resp.data)["token"]
+
+    def _make_admin_token(self, app, user_id):
+        with app.app_context():
+            from backend.app.db import get_db
+            db = get_db()
+            cur = db.cursor()
+            cur.execute("UPDATE users SET is_admin = true WHERE id = %s", (user_id,))
+            cur.close()
+
+        return jwt.encode(
+            {"user_id": user_id, "role": "admin",
+             "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1)},
+            app.config["JWT_SECRET_KEY"],
+            algorithm="HS256",
+        )
+
+    def test_admin_requires_auth(self, client):
+        resp = client.get("/admin")
+        assert resp.status_code == 401
+
+    def test_admin_requires_admin_role(self, client):
+        token = self._register(client)
+        resp = client.get("/admin", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 403
+
+    def test_admin_accessible_with_admin_role(self, client, app):
+        token = self._register(client)
+        payload = jwt.decode(token, app.config["JWT_SECRET_KEY"], algorithms=["HS256"])
+        user_id = payload["user_id"]
+        admin_token = self._make_admin_token(app, user_id)
+
+        resp = client.get("/admin", headers={"Authorization": f"Bearer {admin_token}"})
+        assert resp.status_code == 200
+        assert b"FLAG{jwt_role_change}" in resp.data

--- a/backend/tests/security/test_jwt.py
+++ b/backend/tests/security/test_jwt.py
@@ -1,0 +1,48 @@
+import json
+import datetime
+import jwt
+
+
+class TestJwtRoleManipulation:
+    def _register(self, client, email="attacker@test.com", phone="0501234567"):
+        resp = client.post("/register", json={
+            "email": email,
+            "phone": phone,
+            "password": "password123",
+        })
+        return json.loads(resp.data)["token"]
+
+    def test_jwt_role_manipulation(self, client, app):
+        """Buyer should NOT be able to forge admin token — but can (JWT vuln #12)."""
+        token = self._register(client)
+
+        payload = jwt.decode(token, options={"verify_signature": False})
+        assert payload["role"] == "buyer"
+
+        forged_payload = {
+            "user_id": payload["user_id"],
+            "role": "admin",
+            "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),
+        }
+        forged_token = jwt.encode(forged_payload, app.config["JWT_SECRET_KEY"], algorithm="HS256")
+
+        resp = client.get("/admin", headers={"Authorization": f"Bearer {forged_token}"})
+
+        assert resp.status_code == 403, "JWT role manipulation: forged admin token grants access to /admin"
+
+    def test_jwt_none_algorithm(self, client, app):
+        """None algorithm should be rejected."""
+        token = self._register(client)
+        payload = jwt.decode(token, options={"verify_signature": False})
+
+        import base64
+        header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b'=').decode()
+        body = base64.urlsafe_b64encode(
+            json.dumps({"user_id": payload["user_id"], "role": "admin",
+                         "exp": int((datetime.datetime.utcnow() + datetime.timedelta(hours=1)).timestamp())
+                         }).encode()
+        ).rstrip(b'=').decode()
+        none_token = f"{header}.{body}."
+
+        resp = client.get("/admin", headers={"Authorization": f"Bearer {none_token}"})
+        assert resp.status_code == 401

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -1208,3 +1208,60 @@ img {
     font-size: 0.85rem;
     margin-top: 16px;
 }
+
+/* ===== ADMIN ===== */
+.admin-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 32px;
+}
+
+.admin-title {
+    font-size: 1.5rem;
+}
+
+.admin-flag {
+    padding: 8px 16px;
+    background: rgba(34, 197, 94, 0.15);
+    color: var(--success);
+    border-radius: var(--radius-sm);
+    font-family: monospace;
+    font-size: 0.9rem;
+}
+
+.admin-section {
+    margin-bottom: 32px;
+}
+
+.admin-section h2 {
+    font-size: 1.1rem;
+    margin-bottom: 16px;
+}
+
+.role-badge {
+    padding: 3px 8px;
+    border-radius: 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.role-admin {
+    background: rgba(239, 68, 68, 0.15);
+    color: var(--danger);
+}
+
+.role-seller {
+    background: rgba(59, 130, 246, 0.15);
+    color: var(--accent-blue);
+}
+
+.role-buyer {
+    background: rgba(148, 163, 184, 0.15);
+    color: var(--text-secondary);
+}
+
+.sensitive-data {
+    color: var(--danger);
+    font-family: monospace;
+}

--- a/frontend/templates/admin.html
+++ b/frontend/templates/admin.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+
+{% block title %}Адмін панель — PivdenShop{% endblock %}
+
+{% block content %}
+<section class="section">
+    <div class="admin-header">
+        <h1 class="admin-title">Адмін панель</h1>
+        <div class="admin-flag">FLAG{jwt_role_change}</div>
+    </div>
+
+    <div class="admin-section">
+        <h2>Користувачі ({{ users|length }})</h2>
+        <table class="orders-table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Email</th>
+                    <th>Ім'я</th>
+                    <th>Роль</th>
+                    <th>Дата реєстрації</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in users %}
+                <tr>
+                    <td>{{ user.id }}</td>
+                    <td>{{ user.email }}</td>
+                    <td>{{ user.full_name or '—' }}</td>
+                    <td><span class="role-badge role-{{ user.role }}">{{ user.role }}</span></td>
+                    <td>{{ user.created_at }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="admin-section">
+        <h2>Замовлення ({{ orders|length }})</h2>
+        <table class="orders-table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Покупець</th>
+                    <th>Товар</th>
+                    <th>Карта (last4)</th>
+                    <th>Карта (повний номер)</th>
+                    <th>Статус</th>
+                    <th>Дата</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for order in orders %}
+                <tr>
+                    <td>{{ order.id }}</td>
+                    <td>{{ order.buyer_email }}</td>
+                    <td>{{ order.product_title }}</td>
+                    <td>**** {{ order.card_last4 }}</td>
+                    <td class="sensitive-data">{{ order.card_number_plain or '—' }}</td>
+                    <td><span class="status-badge status-{{ order.status }}">{{ order.status }}</span></td>
+                    <td>{{ order.created_at }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
Closes #46, #55

## Вразливість
- JWT payload довіряється без перевірки по БД
- g.user_role = payload.get('role', 'buyer')
- Слабкий ключ: dev-jwt-secret
- Атака: decode → змінити role → підписати → /admin

## /admin панель
- Всі користувачі з email та role
- Всі замовлення з card_number_plain (подвійний приз)
- FLAG{jwt_role_change} в заголовку

## Тести
- 48 functional ✅
- 6 security ❌ (навмисно)