### PR TITLE
[VULN] Privilege escalation #22 + Sentry #24

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ REDIS_ENABLED=false
 # Admin (basic auth for /api/docs)
 API_DOCS_USERNAME=admin
 API_DOCS_PASSWORD=admin
+
+# Sentry
+SENTRY_DSN=

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,8 +3,16 @@ import os
 from flask import Flask, request, Response
 from functools import wraps
 
+import sentry_sdk
+
 from backend.app.config import Config
 from backend.app.db import close_db, init_db
+
+if Config.SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=Config.SENTRY_DSN,
+        send_default_pii=True,
+    )
 
 
 def _check_basic_auth(username, password):

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,3 +19,5 @@ class Config:
 
     API_DOCS_USERNAME = os.getenv("API_DOCS_USERNAME", "admin")
     API_DOCS_PASSWORD = os.getenv("API_DOCS_PASSWORD", "admin")
+
+    SENTRY_DSN = os.getenv("SENTRY_DSN", "")

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -15,6 +15,10 @@ def admin_panel():
     db = get_db()
     cur = db.cursor()
 
+    cur.execute("SELECT is_admin FROM users WHERE id = %s", (g.user_id,))
+    row = cur.fetchone()
+    is_real_admin = row[0] if row else False
+
     cur.execute(
         "SELECT id, email, full_name, is_seller, is_admin, created_at FROM users ORDER BY id"
     )
@@ -51,7 +55,8 @@ def admin_panel():
 
     cur.close()
 
-    return render_template("admin.html", users=users, orders=orders)
+    privesc = not is_real_admin
+    return render_template("admin.html", users=users, orders=orders, privesc=privesc)
 
 
 @admin_bp.route("/admin/reports/users", methods=["GET"])

--- a/backend/app/routes/main.py
+++ b/backend/app/routes/main.py
@@ -2,9 +2,21 @@ import os
 
 from flask import Blueprint, render_template, current_app, request, jsonify, send_file
 
+from backend.app.config import Config
 from backend.app.db import get_db
 
 main_bp = Blueprint("main", __name__)
+
+
+@main_bp.route("/debug/error", methods=["GET"])
+def debug_error():
+    db_url = Config.DATABASE_URL
+    jwt_secret = Config.JWT_SECRET_KEY
+    error_msg = f"Debug: DB_URL={db_url}, JWT={jwt_secret}"
+    return jsonify({
+        "error": error_msg,
+        "flag": "FLAG{sentry_leak}",
+    }), 500
 
 
 @main_bp.route("/", methods=["GET"])

--- a/backend/tests/functional/test_admin.py
+++ b/backend/tests/functional/test_admin.py
@@ -45,3 +45,20 @@ class TestAdminPanel:
         resp = client.get("/admin", headers={"Authorization": f"Bearer {admin_token}"})
         assert resp.status_code == 200
         assert b"FLAG{jwt_role_change}" in resp.data
+
+    def test_privesc_chain_flag(self, client, app):
+        token = self._register(client)
+        payload = jwt.decode(token, app.config["JWT_SECRET_KEY"], algorithms=["HS256"])
+        user_id = payload["user_id"]
+
+        forged_token = jwt.encode(
+            {"user_id": user_id, "role": "admin",
+             "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1)},
+            app.config["JWT_SECRET_KEY"],
+            algorithm="HS256",
+        )
+
+        resp = client.get("/admin", headers={"Authorization": f"Bearer {forged_token}"})
+        assert resp.status_code == 200
+        assert b"FLAG{jwt_role_change}" in resp.data
+        assert b"FLAG{privesc_chain}" in resp.data

--- a/backend/tests/functional/test_sentry.py
+++ b/backend/tests/functional/test_sentry.py
@@ -1,0 +1,11 @@
+import json
+
+
+class TestSentryLeak:
+    def test_debug_error_exposes_secrets(self, client):
+        resp = client.get("/debug/error")
+        assert resp.status_code == 500
+        data = json.loads(resp.data)
+        assert "DB_URL=" in data["error"]
+        assert "JWT=" in data["error"]
+        assert data["flag"] == "FLAG{sentry_leak}"

--- a/backend/tests/security/test_privesc.py
+++ b/backend/tests/security/test_privesc.py
@@ -1,0 +1,50 @@
+import json
+import datetime
+import jwt
+
+
+class TestPrivescChain:
+    def test_privesc_chain(self, client, app):
+        """Full privilege escalation chain: buyer → seller → admin.
+        Should NOT work — but does (#22)."""
+
+        # Step 1: Register as buyer
+        resp = client.post("/register", json={
+            "email": "chain@test.com",
+            "phone": "0509999999",
+            "password": "password123",
+        })
+        data = json.loads(resp.data)
+        token = data["token"]
+        payload = jwt.decode(token, options={"verify_signature": False})
+        assert payload["role"] == "buyer"
+
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Step 2: Become seller + mass assignment is_verified
+        resp = client.post("/api/become-seller", headers=headers, json={
+            "is_verified": True,
+        })
+        assert resp.status_code == 200
+
+        # Step 3: Forge JWT with role=admin using dev secret
+        forged_payload = {
+            "user_id": payload["user_id"],
+            "role": "admin",
+            "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),
+        }
+        forged_token = jwt.encode(
+            forged_payload,
+            app.config["JWT_SECRET_KEY"],
+            algorithm="HS256",
+        )
+
+        # Step 4: Access admin panel — should be 403 but is 200
+        resp = client.get("/admin", headers={
+            "Authorization": f"Bearer {forged_token}",
+        })
+
+        assert resp.status_code == 403, \
+            "Privesc chain: buyer->seller->admin via JWT forgery grants admin access"
+        assert b"FLAG{privesc_chain}" not in resp.data, \
+            "Privesc chain flag should not be obtainable"

--- a/backend/tests/security/test_sentry.py
+++ b/backend/tests/security/test_sentry.py
@@ -1,0 +1,15 @@
+import json
+
+
+class TestSentryExposure:
+    def test_debug_endpoint_should_not_leak_secrets(self, client):
+        """Debug endpoint should NOT expose DB credentials and JWT secret — but does (#24)."""
+        resp = client.get("/debug/error")
+        data = json.loads(resp.data)
+
+        assert "DB_URL=" not in data.get("error", ""), \
+            "Debug endpoint leaks DATABASE_URL in error message"
+        assert "JWT=" not in data.get("error", ""), \
+            "Debug endpoint leaks JWT_SECRET_KEY in error message"
+        assert data.get("flag") != "FLAG{sentry_leak}", \
+            "Sentry leak flag should not be obtainable"

--- a/frontend/templates/admin.html
+++ b/frontend/templates/admin.html
@@ -7,6 +7,9 @@
     <div class="admin-header">
         <h1 class="admin-title">Адмін панель</h1>
         <div class="admin-flag">FLAG{jwt_role_change}</div>
+        {% if privesc %}
+        <div class="admin-flag">FLAG{privesc_chain}</div>
+        {% endif %}
         <a href="/admin/reports/users" class="btn btn-outline btn-sm" style="margin-left:auto">Звіт по користувачам</a>
     </div>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.0.1
 PyJWT==2.10.1
 flasgger==0.9.7.1
 requests==2.32.3
+sentry-sdk[flask]==2.19.2


### PR DESCRIPTION
Closes #22, #24 (из issues спринта 3)

## Вразливості
- **#22 Privesc chain:** register → become-seller → forge JWT → /admin
  - `FLAG{privesc_chain}` якщо `is_admin=false` в БД
  - `FLAG{jwt_role_change}` при будь-якому доступі
- **#24 Sentry:** `send_default_pii=True`
  - `/debug/error` → DB_URL + JWT_SECRET витікають
  - `FLAG{sentry_leak}`

## Тести
- 67 functional ✅
- 19 security ❌ (навмисно)